### PR TITLE
chore: add package.json repository, bugs and page

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "mr-krabs",
   "version": "1.0.0",
   "description": "A package to clear Fargate cluster tasks",
+  "homepage": "https://github.com/pagarme/mr-krabs#readme",
+  "bugs": "https://github.com/pagarme/mr-krabs/issues",
   "main": "lib/index.js",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/pagarme/mr-krabs.git"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This PRs adds to `package.json`:
- bugs url
- homepage url
- repository information

The npm use this information to link the package description on the npm package page